### PR TITLE
Add intelligent skip labels and enhance Docusign support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,17 +210,21 @@ The system supports multiple regex patterns for contract completion emails:
 - `getConfiguredSenderEmails()` - Get all configured sender emails dynamically (supports up to 20)
 - `testProcessEmails()` - Test function for manual email processing
 - `debugHelloSignEmails()` - Debug HelloSign email processing specifically (pattern matching, sender config)
+- `debugDocusignEmails()` - Debug Docusign email processing specifically
 - `checkProperties()` - View current property usage and statistics (alias for showAllProperties)
 - `cleanupOld(days, dryRun)` - Clean up processed messages older than X days (alias)
 - `fixProperties()` - Emergency cleanup when property limit is reached (alias)
+- `showSkippedEmailStats()` or `checkSkipped()` - Display statistics for skipped emails
+- `cleanupOldSkipLabels(days, dryRun)` - Remove skip labels from old emails
 
 ### emailProcessor.js
 - `processMessage()` - Process individual contract emails with enhanced metadata
-- `checkSubjectPattern()` - Multi-pattern contract matching (includes Dropbox Sign)
+- `checkSubjectPattern()` - Multi-pattern contract matching (includes Dropbox Sign and Docusign)
 - `isMessageAlreadyProcessed()` - Spreadsheet-based duplicate prevention
 - `getMessageRecipients()` - Extract all recipients (To, CC, BCC) from message
 - `extractEmailAddresses()` - Extract email addresses from recipient field string
 - `createRecipientHash()` - Create hash for recipient combination tracking
+- **Auto-skip feature**: Automatically adds `Contract_Skipped` label to non-matching emails
 
 ### driveManager.js
 - `processAttachments()` - Handle contract PDF saving with intelligent duplicate detection

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A specialized Google Apps Script-based system designed for contract management w
 - ⏰ **Automated Scheduling**: Continuous monitoring every 5 minutes
 - 🔄 **Smart Duplicate Prevention**: Content-based detection prevents duplicate PDF storage while ensuring all recipients receive notifications
 - 📊 **Unlimited Tracking**: Spreadsheet-based duplicate tracking with no Script Properties limitations
+- 🏷️ **Intelligent Skip Labels**: Automatically skips non-contract emails to prevent repeated checking
 - 🛡️ **Error Recovery**: Robust error handling with detailed logging
 - 📊 **Performance Monitoring**: Built-in analytics and health checks
 
@@ -716,6 +717,8 @@ contract-management-processor/
 - `getOrCreateDriveFolder()`: Drive folder management
 - 🆕 `markMessageAsProcessed()`: Store processed message IDs
 - 🆕 `cleanupOldProcessedMessages()`: Maintenance function for old records
+- 🆕 `showSkippedEmailStats()` or `checkSkipped()`: Display statistics for skipped emails
+- 🆕 `cleanupOldSkipLabels()`: Remove skip labels from old emails
 
 #### `emailProcessor.js`
 - `processMessage()`: Individual email processing with duplicate prevention and recipient tracking
@@ -723,6 +726,7 @@ contract-management-processor/
 - 🆕 `formatEmailBody()`: Smart email content formatting (up to 7500 chars)
 - 🆕 `getMessageRecipient()`: Extract recipient email from message To field
 - 🆕 `extractEmailAddresses()`: Parse multiple email addresses from string
+- 🆕 **Auto-skip feature**: Adds `Contract_Skipped` label to non-matching emails
 
 #### `driveManager.js`
 - 🆕 `processAttachments()`: PDF-only contract processing
@@ -1021,6 +1025,18 @@ Sending follow-up message for 2 saved PDFs...
 **License**: MIT License
 
 ## Recent Updates
+
+### 🆕 Version 2.6 - Intelligent Skip Labels & Enhanced Docusign Support
+- **Smart Skip Labels**: Automatically adds `Contract_Skipped` label to non-matching emails
+  - Prevents repeated checking of irrelevant emails
+  - Reduces processing overhead and improves performance
+  - Includes emails without PDF attachments (for Docusign)
+- **Skip Email Management**:
+  - `showSkippedEmailStats()` or `checkSkipped()` - View statistics of skipped emails
+  - `cleanupOldSkipLabels(days, dryRun)` - Clean up old skip labels
+  - Review skipped emails in Gmail with search: `label:Contract_Skipped`
+- **Enhanced Search Query**: Now excludes both `Contract_Processed` and `Contract_Skipped` labels
+- **Improved Docusign Detection**: Better handling of emails without PDF attachments
 
 ### 🆕 Version 2.5 - HelloSign Support & Testing Improvements
 - **HelloSign/Dropbox Sign Integration**: Full support for HelloSign email processing


### PR DESCRIPTION
- Implement automatic Contract_Skipped label for non-matching emails
- Add skip label to search query exclusions (-label:Contract_Skipped)
- Add showSkippedEmailStats() and cleanupOldSkipLabels() functions
- Add Japanese Docusign patterns (完了: Complete with Docusign:)
- Support forwarded Docusign emails (Fwd: patterns)
- Enhance both regular and Docusign-specific pattern matching
- Update README and CLAUDE.md with new features

This prevents repeated checking of irrelevant emails and improves processing efficiency for contract management workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)